### PR TITLE
Fixes GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Use the current pages-specific artifact upload action
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Use the current pages-specific artifact upload action
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:

--- a/ACTIONS_FIX_SUMMARY.md
+++ b/ACTIONS_FIX_SUMMARY.md
@@ -1,0 +1,66 @@
+# GitHub Actions Deprecated Actions Fix - Summary
+
+## Problem
+The repository was encountering an error about deprecated `actions/upload-artifact@v3` being used in GitHub Pages deployment:
+
+```
+Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
+```
+
+## Root Cause
+The error was coming from GitHub's automatically generated workflow for GitHub Pages deployment. When you enable GitHub Pages for a repository with Jekyll content, GitHub automatically creates workflows that were using the deprecated `actions/upload-artifact@v3` action.
+
+## Solution Implemented
+Created a custom GitHub Pages deployment workflow (`.github/workflows/pages.yml`) that:
+
+1. **Uses Current Actions**: Replaced deprecated actions with current versions:
+   - `actions/checkout@v4` (latest)
+   - `actions/configure-pages@v5` (latest)
+   - `actions/upload-pages-artifact@v3` (current for Pages-specific uploads)
+   - `actions/deploy-pages@v4` (latest)
+
+2. **Proper Workflow Structure**: 
+   - Separate build and deploy jobs
+   - Correct permissions (`pages: write`, `id-token: write`)
+   - Proper concurrency handling
+
+3. **Jekyll Support**: 
+   - Added `Gemfile` with proper Jekyll dependencies
+   - Uses `ruby/setup-ruby@v1` with bundler caching
+   - Builds with production environment
+
+## Key Differences from Deprecated Approach
+
+### ❌ OLD (Deprecated):
+- Used `actions/upload-artifact@v3` (general-purpose action)
+- GitHub's automatic workflow with deprecated actions
+
+### ✅ NEW (Fixed):
+- Uses `actions/upload-pages-artifact@v3` (Pages-specific action)
+- Custom workflow with latest action versions
+- Proper Jekyll dependency management
+
+## Files Added/Modified
+
+1. **`.github/workflows/pages.yml`** - Custom GitHub Pages deployment workflow
+2. **`Gemfile`** - Jekyll dependencies for bundler
+
+## Expected Outcome
+
+- ✅ No more deprecation warnings
+- ✅ Faster deployments with latest actions
+- ✅ Better reliability with Pages-specific actions
+- ✅ Proper Jekyll dependency management
+- ✅ Automatic deployment on pushes to main branch
+
+## Next Steps
+
+1. Monitor the workflow runs at: `https://github.com/chevyphillip/python-data-structures-practice/actions`
+2. Verify the GitHub Pages site deploys successfully
+3. Consider merging this branch to main to apply the fix
+
+## References
+
+- [GitHub Blog: Deprecation Notice for v3 of artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
+- [GitHub Pages Action Documentation](https://github.com/actions/upload-pages-artifact)
+- [Jekyll GitHub Pages Deployment Best Practices](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll)

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,24 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3.0"
+gem "minima", "~> 2.5"
+
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-sitemap"
+  gem "jekyll-seo-tag"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]


### PR DESCRIPTION
Addresses an issue with deprecated actions in the GitHub Pages deployment workflow.

- Replaces deprecated `actions/upload-artifact@v3` with the pages-specific `actions/upload-pages-artifact@v4`.
- Updates the GitHub Pages workflow to use current action versions for improved reliability and performance.
- Introduces a custom workflow with proper Jekyll support, including dependency management.